### PR TITLE
re-sending as Updates 6.4.2024.md

### DIFF
--- a/Updates 6.4.2024.md
+++ b/Updates 6.4.2024.md
@@ -1,0 +1,4 @@
+line 90:  changed bNAT to 5e-4 (from Weimer et al, 2023)
+line 108: changed 'dela' to 32 Tg/yr  to be commensurate with the SO2 input level in the 2022 WMO report scenario
+line 110: activated the calculation of 'daec' (instead of the column data calculation on lines 112 and 113)
+line 181: changed ni to daec (mass density of SO2, per your previous recommendation) in calculation


### PR DESCRIPTION
I sent these changes in another pull request earlier today, but I inadvertently merged them into the code, so I'm re-sending them in a new pull request for visibility, even though they're already in the code now.  

With these changes, SAI results for (R1) show dO3 of -1.57 x 10^4 molec cm^-3 s^-1 for 2024, decreasing to -1.2 x 10^4 by 2050, after subtracting out dObt, the O3 depletion from baseline aerosol as NAT.